### PR TITLE
Minor backend fixes

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -7,7 +7,8 @@ from django.db.models.functions import TruncDate
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.views import APIView
+from rest_framework import generics
+
 from rest_framework.viewsets import ModelViewSet
 
 import pandas as pd
@@ -15,15 +16,14 @@ import pandas as pd
 from .models import Stations, Regions, RegionReadings, StationReadingsGold, InferenceRuns, InferenceResults
 from .serializers import StationSerializer, RegionSerializer, MapSerializer, ForecastSerializer, HistorySerializer
 
-
-class HealthCheckView(APIView):
+class HealthCheckView(generics.GenericAPIView):
     http_method_names = ['get']
 
     def get(self, request, *args, **kwargs):
         return Response({"status": "ok"}, status=status.HTTP_200_OK)
 
 
-class MapViewset(APIView):
+class MapViewset(generics.GenericAPIView):
     http_method_names = ['get']
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
**Description**
This Pr addresses minor backend errors that came from the deployment from production.
The error log showed: 
```
app/api/views.py: Error [HealthCheckView]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
/app/api/views.py: Error [MapViewset]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
/app/api/serializers.py: Warning [StationViewset > StationSerializer]: unable to resolve type hint for function "coordinates". Consider using a type hint or @extend_schema_field. Defaulting to string.

```
This changes `ApiView` to `GenericApiView` to address it. 
