### PR TITLE
Backend - map/ and station/forecasts/ endpoint fix

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -127,17 +127,10 @@ class StationViewset(ModelViewSet):
         
         last_inference = InferenceResults.objects.filter(station=station.id).order_by('-inference_run_id').first()
         inference_run = InferenceRuns.objects.filter(id=last_inference.inference_run_id).first()
-        
-        historical = (
-            StationReadingsGold.objects.filter(station_id=station.id)
-            .order_by('date_utc')
-            .values('date_utc', 'aqi_level')
-            .first()
-        )
 
         return Response({
             "forecast_date": inference_run.run_date,
-            "aqi_level": historical['aqi_level'],
+            "aqi_level": pd.DataFrame(last_inference.aqi_input).to_dict(orient='records'),
             "forecast_6h": pd.DataFrame(last_inference.forecasts_6h).to_dict(orient='records'),
             "forecast_12h": pd.DataFrame(last_inference.forecasts_12h).to_dict(orient='records')
         }, status=status.HTTP_200_OK)


### PR DESCRIPTION
Minor changes in views.py

* api/map/: use aqi_pm2_5 instead of aqi_level to get latest aqi_pm2_5 reading for a station
* api/station/{id}/forecast: use aqi_input from InferenceResults instead of last aqi value from StationReadingsGold as input.