### PR TITLE
Fix issues with weekly chart and minor improvements

### DIFF
--- a/frontend/src/components/react/data-viz/BoxPlotChart.tsx
+++ b/frontend/src/components/react/data-viz/BoxPlotChart.tsx
@@ -4,33 +4,20 @@ import { useStore } from "@nanostores/react";
 import { ResponsiveBoxPlot } from "@nivo/boxplot";
 import { DateTime } from "luxon";
 import { boxplotMonthData, boxplotWeekData, boxplotYearData, errorBoxplotMonth, errorBoxplotWeek, errorBoxplotYear, loadingBoxplotMonth, loadingBoxplotWeek, loadingBoxplotYear } from "../../../store/statistics";
-const data = {
-  x: [
-    "2024-12-18",
-    "2024-12-17",
-    "2024-12-16",
-    "2024-12-15",
-    "2024-12-14",
-    "2024-12-13",
-    "2024-12-12",
-  ],
-  q1: [57.5, 29, 16.25, 10, 7.25, 7, 29],
-  median: [60, 31, 19, 10, 8, 9, 30],
-  q3: [64, 44, 21, 13, 9, 10.25, 30.75],
-  lowerfence: [57, 29, 14, 10, 7, 7, 26.375],
-  upperfence: [65, 56, 27, 14, 10, 15.125, 31],
-};
+
 const quantiles = [0, 0.25, 0.5, 0.75, 1];
 
-const formatterWeek = (date: string, { index }: { index?: number }) => DateTime.fromFormat(date, "yyyy-mm-dd", { locale: "es" })
-  .weekdayShort || ""
+const formatterWeek = (date: string, { index }: { index?: number }) => { 
+  const parsedDate = DateTime.fromFormat(date, "yyyy-MM-dd", { locale: "es" })
+  return parsedDate.weekdayShort + "-" + parsedDate.day
+}
 const formatterMonth = (date: string, { index }: { index?: number }) => index !== undefined ? (index + 1) + "W" : ""
 const formatterYear = (date: string, { index }: { index?: number }) => date
 
 const processData = (data: any, formatter: (date: string, { index }: { index?: number }) => string) => {
   if (!data) { return }
   const size = data["x"].length;
-  return data["x"].reverse().map((_: any, index: number) => ({
+  return data["x"].map((_: any, index: number) => ({
     group: formatter(data["x"][index], { index }),
     subGroup: "",
     mean: data["median"][index],
@@ -56,6 +43,7 @@ export const BoxPlotChart = ({ period }: { period: "7d" | "30d" | "1y" }) => {
     loading = useStore(loadingBoxplotWeek)
     error = useStore(errorBoxplotWeek)
     data = processData(useStore(boxplotWeekData), formatterWeek);
+    console.log("processData",data)
   }
   if (period === "30d") {
     loading = useStore(loadingBoxplotMonth)

--- a/frontend/src/components/react/data-viz/BoxPlotChart.tsx
+++ b/frontend/src/components/react/data-viz/BoxPlotChart.tsx
@@ -7,17 +7,20 @@ import { boxplotMonthData, boxplotWeekData, boxplotYearData, errorBoxplotMonth, 
 
 const quantiles = [0, 0.25, 0.5, 0.75, 1];
 
-const formatterWeek = (date: string, { index }: { index?: number }) => { 
+const formatterWeek = (date: string) => { 
   const parsedDate = DateTime.fromFormat(date, "yyyy-MM-dd", { locale: "es" })
   return parsedDate.weekdayShort + "-" + parsedDate.day
 }
-const formatterMonth = (date: string, { index }: { index?: number }) => index !== undefined ? (index + 1) + "W" : ""
-const formatterYear = (date: string, { index }: { index?: number }) => date
+const formatterMonth = (_:string, { index }: { index?: number }) => index !== undefined ? (index + 1) + "W" : ""
+const formatterYear = (date: string) =>  { 
+  const parsedDate = DateTime.fromFormat(date, "yyyy-MM-dd", { locale: "es" }) 
+  return parsedDate.monthShort + "-" + parsedDate.toFormat("yy")
+}
 
 const processData = (data: any, formatter: (date: string, { index }: { index?: number }) => string) => {
   if (!data) { return }
   const size = data["x"].length;
-  return data["x"].map((_: any, index: number) => ({
+  return data["x"].sort().map((_: any, index: number) => ({
     group: formatter(data["x"][index], { index }),
     subGroup: "",
     mean: data["median"][index],
@@ -43,7 +46,6 @@ export const BoxPlotChart = ({ period }: { period: "7d" | "30d" | "1y" }) => {
     loading = useStore(loadingBoxplotWeek)
     error = useStore(errorBoxplotWeek)
     data = processData(useStore(boxplotWeekData), formatterWeek);
-    console.log("processData",data)
   }
   if (period === "30d") {
     loading = useStore(loadingBoxplotMonth)
@@ -55,8 +57,6 @@ export const BoxPlotChart = ({ period }: { period: "7d" | "30d" | "1y" }) => {
     error = useStore(errorBoxplotYear)
     data = processData(useStore(boxplotYearData), formatterYear);
   }
-  console.log(error)
-
   return (
     <>
       {loading && !data && (

--- a/frontend/src/pages/datos/[...slug].astro
+++ b/frontend/src/pages/datos/[...slug].astro
@@ -6,18 +6,21 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import Footer from "../../components/atoms/Footer.astro";
 import { HistoricLineChart } from "../../components/react/data-viz/HistoricLineChart.tsx";
 import { BoxPlotChart } from "../../components/react/data-viz/BoxPlotChart.tsx";
-import { statisticsSelectedStation, statisticsStationId } from "../../store/statistics";
+import {
+  statisticsSelectedStation,
+  statisticsStationId,
+} from "../../store/statistics";
 import PlaceHolderMap from "../../components/react/PlaceholderMap";
 import BackTop from "../../components/atoms/BackTop.astro";
-import {CharacteristicsStation} from "../../components/react/statistics/Characteristics"
-import {HeaderStatistics} from "../../components/react/statistics/Header"
+import { CharacteristicsStation } from "../../components/react/statistics/Characteristics";
+import { HeaderStatistics } from "../../components/react/statistics/Header";
 
 const { slug } = Astro.params;
-statisticsStationId.set(undefined)
+statisticsStationId.set(undefined);
 if (!slug) return Astro.redirect("/404");
-const stationId=parseInt(slug)
-if(Number.isNaN(stationId))  return Astro.redirect("/404");
-statisticsStationId.set(stationId)
+const stationId = parseInt(slug);
+if (Number.isNaN(stationId)) return Astro.redirect("/404");
+statisticsStationId.set(stationId);
 ---
 
 <BaseLayout>
@@ -43,18 +46,16 @@ statisticsStationId.set(stationId)
       las próximas 6 y 12 horas.</Typography
     >
     <div class="flex overflow-x-auto">
-    <div class="h-[450px] w-full min-w-[60rem]">
-      <HistoricLineChart client:only="react" />
+      <div class="h-[450px] w-full min-w-[60rem]">
+        <HistoricLineChart client:only="react" />
+      </div>
     </div>
-  </div>
     <Typography variant="h3" customClass="pt-10"
       >Histórico: Índice de calidad del aire</Typography
     >
     <Typography variant="p">Historial de mediciones de los sensores.</Typography
     >
-    <div
-      class="grid md:grid-cols-2 grid-cols-1 mt-12  space-x-4 space-y-4"
-    >
+    <div class="grid md:grid-cols-2 grid-cols-1 mt-12 space-x-4 space-y-4">
       <div class="col-span-1">
         <Typography variant="h6">Última semana</Typography>
         <div class="h-[450px] w-full">
@@ -69,7 +70,12 @@ statisticsStationId.set(stationId)
       </div>
       <div class="col-span-1 md:col-span-2">
         <Typography variant="h6">Último año</Typography>
-        <div class="h-[450px] w-full">
+        <div class="flex overflow-x-auto  md:hidden">
+          <div class="h-[450px] w-full min-w-[40rem]">
+            <BoxPlotChart client:only="react" period="1y" />
+          </div>
+        </div>
+        <div class="h-[500px] max-h-[450px] w-full hidden md:block overflow-clip">
           <BoxPlotChart client:only="react" period="1y" />
         </div>
       </div>


### PR DESCRIPTION
### Description
This PR addresses an issue with the weekly chart not being displayed correctly on prod. 
The issue was that the endpoint for the week was returning 8 values instead of 7 making a day repeat itself and thus making the grouping for the boxplot fail due to a key duplication. 
To address this the day number is appended to the weekday shortname. 
Additionally this PR fixes a rendering issue for the yearly chart that on mobile the labels cluttered by making it a scrollable boxplot chart. 
Minor code clean is also included in this PR.
This should fix the remaining issue on #53
