### PR TITLE
[RES-179] - Bugs reportados

### DIFF
--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -184,6 +184,41 @@ class BackendEndpointTests(TestCase):
             [{"timestamp": "2026-03-31 12:00:00", "value": 35.0}],
         )
 
+    def test_region_map_uses_latest_run_with_valid_forecast_data(self):
+        newer_empty_run = InferenceRuns.objects.create(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+            run_date=datetime(2026, 3, 31, 13, 0, tzinfo=timezone.utc),
+        )
+        InferenceResults.objects.create(
+            inference_run=newer_empty_run,
+            station=self.station,
+            forecasts_6h=[],
+            forecasts_12h=[],
+            aqi_input=[{"timestamp": "2026-03-31 12:00:00", "value": 84}],
+        )
+        InferenceResults.objects.create(
+            inference_run=newer_empty_run,
+            station=self.region_station_2,
+            forecasts_6h=[],
+            forecasts_12h=[],
+            aqi_input=[{"timestamp": "2026-03-31 12:00:00", "value": 60}],
+        )
+
+        response = self.client.get(
+            reverse("map"), {"entity": "region", "id": self.region.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["forecast_6h"],
+            [{"timestamp": "2026-03-31 12:00:00", "value": 30.0}],
+        )
+        self.assertEqual(
+            payload["forecast_12h"],
+            [{"timestamp": "2026-03-31 12:00:00", "value": 35.0}],
+        )
+
     def test_station_forecast_uses_latest_run_date_not_latest_uuid(self):
         response = self.client.get(reverse("stations-forecast", args=[self.station.id]))
 
@@ -202,4 +237,32 @@ class BackendEndpointTests(TestCase):
         )
         self.assertEqual(
             payload["forecast_12h"], [{"timestamp": "2026-03-31 12:00:00", "value": 25}]
+        )
+
+    def test_station_map_uses_latest_run_with_valid_forecast_data(self):
+        newer_empty_run = InferenceRuns.objects.create(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000003"),
+            run_date=datetime(2026, 3, 31, 13, 30, tzinfo=timezone.utc),
+        )
+        InferenceResults.objects.create(
+            inference_run=newer_empty_run,
+            station=self.station,
+            forecasts_6h=[],
+            forecasts_12h=[],
+            aqi_input=[{"timestamp": "2026-03-31 12:30:00", "value": 84}],
+        )
+
+        response = self.client.get(
+            reverse("map"), {"entity": "station", "id": self.station.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["forecast_6h"],
+            [{"timestamp": "2026-03-31 12:00:00", "value": 20}],
+        )
+        self.assertEqual(
+            payload["forecast_12h"],
+            [{"timestamp": "2026-03-31 12:00:00", "value": 25}],
         )

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -147,7 +147,9 @@ class MapViewset(generics.GenericAPIView):
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
-            result_forecast_6h, result_forecast_12h = _latest_region_forecasts(entity_id)
+            result_forecast_6h, result_forecast_12h = _latest_region_forecasts(
+                entity_id
+            )
 
             if not result_forecast_6h or not result_forecast_12h:
                 return Response(

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -48,6 +48,56 @@ def _mean_forecast_by_timestamp(rows):
     ]
 
 
+def _latest_region_forecasts(region_id):
+    candidate_runs = (
+        InferenceRuns.objects.filter(inferenceresults__station__region_id=region_id)
+        .distinct()
+        .order_by("-run_date")
+    )
+
+    for inference_run in candidate_runs:
+        run_results = InferenceResults.objects.filter(
+            inference_run=inference_run,
+            station__region_id=region_id,
+        )
+        forecast_6h = _mean_forecast_by_timestamp(
+            run_results.values_list("forecasts_6h", flat=True)
+        )
+        forecast_12h = _mean_forecast_by_timestamp(
+            run_results.values_list("forecasts_12h", flat=True)
+        )
+
+        if forecast_6h and forecast_12h:
+            return forecast_6h, forecast_12h
+
+    return [], []
+
+
+def _latest_station_forecasts(station_id):
+    candidate_runs = (
+        InferenceRuns.objects.filter(inferenceresults__station_id=station_id)
+        .distinct()
+        .order_by("-run_date")
+    )
+
+    for inference_run in candidate_runs:
+        run_results = InferenceResults.objects.filter(
+            inference_run=inference_run,
+            station_id=station_id,
+        )
+        forecast_6h = _flatten_forecast_rows(
+            run_results.values_list("forecasts_6h", flat=True)
+        )
+        forecast_12h = _flatten_forecast_rows(
+            run_results.values_list("forecasts_12h", flat=True)
+        )
+
+        if forecast_6h and forecast_12h:
+            return forecast_6h, forecast_12h
+
+    return [], []
+
+
 class HealthCheckView(generics.GenericAPIView):
     serializer_class = HealthSerializer
     http_method_names = ["get"]
@@ -84,13 +134,6 @@ class MapViewset(generics.GenericAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        latest_inference_run = InferenceRuns.objects.order_by("-run_date").first()
-        if latest_inference_run is None:
-            return Response(
-                {"error": "No inference runs available."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
-
         if entity == "region":
             latest_region_reading = (
                 RegionReadings.objects.filter(region_id=entity_id)
@@ -104,16 +147,7 @@ class MapViewset(generics.GenericAPIView):
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
-            forecast_results = InferenceResults.objects.filter(
-                inference_run=latest_inference_run,
-                station__region_id=entity_id,
-            )
-            result_forecast_6h = _mean_forecast_by_timestamp(
-                forecast_results.values_list("forecasts_6h", flat=True)
-            )
-            result_forecast_12h = _mean_forecast_by_timestamp(
-                forecast_results.values_list("forecasts_12h", flat=True)
-            )
+            result_forecast_6h, result_forecast_12h = _latest_region_forecasts(entity_id)
 
             if not result_forecast_6h or not result_forecast_12h:
                 return Response(
@@ -158,11 +192,8 @@ class MapViewset(generics.GenericAPIView):
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
-            result_forecast_6h = _flatten_forecast_rows(
-                InferenceResults.objects.filter(
-                    inference_run=latest_inference_run,
-                    station_id=entity_id,
-                ).values_list("forecasts_6h", flat=True)
+            result_forecast_6h, result_forecast_12h = _latest_station_forecasts(
+                entity_id
             )
             if not result_forecast_6h:
                 return Response(
@@ -170,12 +201,6 @@ class MapViewset(generics.GenericAPIView):
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
-            result_forecast_12h = _flatten_forecast_rows(
-                InferenceResults.objects.filter(
-                    inference_run=latest_inference_run,
-                    station_id=entity_id,
-                ).values_list("forecasts_12h", flat=True)
-            )
             if not result_forecast_12h:
                 return Response(
                     {"error": "No 12-hour forecast data available for this station."},


### PR DESCRIPTION
This pull request improves the logic for selecting forecast data in the map API endpoint to ensure it always returns the most recent run that contains valid forecast data, rather than simply using the latest run by date. It introduces new helper functions to encapsulate this selection logic and adds tests to verify the new behavior.

**Forecast selection improvements:**

* Added `_latest_region_forecasts` and `_latest_station_forecasts` helper functions in `backend/api/views.py` to iterate through inference runs in descending order by date and return forecasts from the first run containing valid 6h and 12h forecast data.
* Updated the map API endpoint in `backend/api/views.py` to use these new helper functions instead of always using the latest run, ensuring only runs with valid forecast data are returned. [[1]](diffhunk://#diff-585b0663a266246ad03c1bd2a7022a5a9b795b87285a64517115c2c18dbc8a09L87-L93) [[2]](diffhunk://#diff-585b0663a266246ad03c1bd2a7022a5a9b795b87285a64517115c2c18dbc8a09L107-R150) [[3]](diffhunk://#diff-585b0663a266246ad03c1bd2a7022a5a9b795b87285a64517115c2c18dbc8a09L161-L178)

**Testing enhancements:**

* Added `test_region_map_uses_latest_run_with_valid_forecast_data` and `test_station_map_uses_latest_run_with_valid_forecast_data` in `backend/api/tests.py` to confirm the endpoint selects the latest run with available forecast data, even if newer runs exist without valid data. [[1]](diffhunk://#diff-50bff3ad0a9f7256a447c44f2c900978739a844ba39a99c61b35f7a5d74c4bfbR187-R221) [[2]](diffhunk://#diff-50bff3ad0a9f7256a447c44f2c900978739a844ba39a99c61b35f7a5d74c4bfbR241-R268)