### PR TITLE
[RES-148] - Update forecast() method to return latest inference per station

### DIFF
--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -364,3 +364,33 @@ class BackendEndpointTests(TestCase):
         self.assertEqual(
             payload["forecast_6h"], [{"timestamp": "2026-03-31 12:00:00", "value": 20}]
         )
+
+    def test_station_forecast_falls_back_when_latest_success_has_empty_forecasts(self):
+        newer_success_run = self._create_inference_run(
+            run_id=uuid.UUID("00000000-0000-0000-0000-000000000005"),
+            run_date=datetime(2026, 3, 31, 14, 30, tzinfo=timezone.utc),
+            flow_run_id="flow-run-success-empty-forecast",
+            status=InferenceRuns.Status.SUCCESS,
+        )
+        InferenceResults.objects.create(
+            inference_run=newer_success_run,
+            station=self.station,
+            forecasts_6h=[],
+            forecasts_12h=[],
+            aqi_input=[{"timestamp": "2026-03-31 14:00:00", "value": 120}],
+        )
+
+        response = self.client.get(reverse("stations-forecast", args=[self.station.id]))
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["forecast_date"], "2026-03-31T12:00:00Z")
+        self.assertEqual(
+            payload["aqi_level"], [{"timestamp": "2026-03-31 11:00:00", "value": 84}]
+        )
+        self.assertEqual(
+            payload["forecast_6h"], [{"timestamp": "2026-03-31 12:00:00", "value": 20}]
+        )
+        self.assertEqual(
+            payload["forecast_12h"], [{"timestamp": "2026-03-31 12:00:00", "value": 25}]
+        )

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -104,6 +104,23 @@ def _latest_station_forecasts(station_id):
     return None, [], []
 
 
+def _latest_station_inference_result(station_id):
+    candidate_results = (
+        InferenceResults.objects.filter(
+            station_id=station_id,
+            inference_run__status=InferenceRuns.Status.SUCCESS,
+        )
+        .select_related("inference_run")
+        .order_by("-inference_run__run_date", "-inference_run__created_at")[:50]
+    )
+
+    for inference_result in candidate_results:
+        if inference_result.forecasts_6h and inference_result.forecasts_12h:
+            return inference_result
+
+    return None
+
+
 class HealthCheckView(generics.GenericAPIView):
     serializer_class = HealthSerializer
     http_method_names = ["get"]
@@ -246,15 +263,7 @@ class StationViewset(ModelViewSet):
     @action(detail=True, methods=["get"])
     def forecast(self, request, *args, **kwargs):
         station = self.get_object()
-        last_inference = (
-            InferenceResults.objects.filter(
-                station=station,
-                inference_run__status=InferenceRuns.Status.SUCCESS,
-            )
-            .select_related("inference_run")
-            .order_by("-inference_run__run_date", "-inference_run__created_at")
-            .first()
-        )
+        last_inference = _latest_station_inference_result(station.id)
 
         if last_inference is None:
             return Response(


### PR DESCRIPTION
This pull request improves how the station forecast endpoint selects the most recent inference result. Specifically, it ensures that if the latest successful inference run has empty forecasts, the API will fall back to the next most recent result with valid forecast data. This prevents the endpoint from returning incomplete or empty forecast data to users.

Key changes:

**Forecast selection logic:**
* Added a new helper function `_latest_station_inference_result` in `views.py` that iterates through recent successful inference results and returns the most recent one that has both `forecasts_6h` and `forecasts_12h` populated.
* Updated the `forecast` action in the station view to use this new helper function instead of simply selecting the latest successful run, ensuring valid forecast data is always returned.

**Testing:**
* Added a test `test_station_forecast_falls_back_when_latest_success_has_empty_forecasts` in `tests.py` to verify that the API correctly falls back to an earlier inference result when the latest has empty forecasts.