### PR TITLE
[RES-151] Hide inactive stations from station list and map views

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,6 @@ BACKEND_POSTGRES_SSLMODE=require
 # Runtime options
 BACKEND_RUN_MIGRATIONS=false
 BACKEND_CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+# Maximum age (in hours, relative to the latest network reading) for a station
+# to be considered active in /api/stations.
+BACKEND_ACTIVE_STATION_DATA_MAX_AGE_HOURS=6

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,7 @@ BACKEND_POSTGRES_SSLMODE=require
 
 BACKEND_RUN_MIGRATIONS=false
 BACKEND_CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+BACKEND_ACTIVE_STATION_DATA_MAX_AGE_HOURS=6
 ```
 
 If your provider requires a CA bundle or client certificate, also set:

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -46,6 +46,9 @@ class StationSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.FLOAT)
     def get_aqi_pm2_5(self, obj) -> float | None:
+        if hasattr(obj, "latest_aqi_pm2_5"):
+            return obj.latest_aqi_pm2_5
+
         last_reading = (
             StationReadingsGold.objects.filter(station_id=obj.id)
             .order_by("-date_utc")

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -92,6 +92,51 @@ class BackendEndpointTests(TestCase):
             is_station_on=True,
             is_pattern_station=False,
         )
+        self.stale_station = Stations.objects.create(
+            id=301,
+            name="AireLibre: Stale",
+            region=self.region,
+            latitude=-25.25,
+            longitude=-57.46,
+            is_station_on=True,
+            is_pattern_station=False,
+        )
+        self.no_aqi_station = Stations.objects.create(
+            id=302,
+            name="AireLibre: No AQI",
+            region=self.region,
+            latitude=-25.31,
+            longitude=-57.52,
+            is_station_on=True,
+            is_pattern_station=False,
+        )
+        self.off_station = Stations.objects.create(
+            id=303,
+            name="AireLibre: Off",
+            region=self.region,
+            latitude=-25.32,
+            longitude=-57.53,
+            is_station_on=False,
+            is_pattern_station=False,
+        )
+        self.pattern_station = Stations.objects.create(
+            id=304,
+            name="Pattern Station",
+            region=self.region,
+            latitude=-25.33,
+            longitude=-57.54,
+            is_station_on=True,
+            is_pattern_station=True,
+        )
+        self.no_coordinates_station = Stations.objects.create(
+            id=305,
+            name="AireLibre: No Coordinates",
+            region=self.region,
+            latitude=None,
+            longitude=None,
+            is_station_on=True,
+            is_pattern_station=False,
+        )
 
         latest_reading_time = datetime(2026, 3, 31, 12, 0, tzinfo=timezone.utc)
         StationReadingsGold.objects.create(
@@ -108,6 +153,31 @@ class BackendEndpointTests(TestCase):
             station=self.other_station,
             date_utc=latest_reading_time,
             aqi_pm2_5=150.0,
+        )
+        StationReadingsGold.objects.create(
+            station=self.stale_station,
+            date_utc=latest_reading_time - timedelta(hours=7),
+            aqi_pm2_5=77.0,
+        )
+        StationReadingsGold.objects.create(
+            station=self.no_aqi_station,
+            date_utc=latest_reading_time,
+            aqi_pm2_5=None,
+        )
+        StationReadingsGold.objects.create(
+            station=self.off_station,
+            date_utc=latest_reading_time,
+            aqi_pm2_5=55.0,
+        )
+        StationReadingsGold.objects.create(
+            station=self.pattern_station,
+            date_utc=latest_reading_time,
+            aqi_pm2_5=58.0,
+        )
+        StationReadingsGold.objects.create(
+            station=self.no_coordinates_station,
+            date_utc=latest_reading_time,
+            aqi_pm2_5=59.0,
         )
         RegionReadings.objects.create(
             region=self.region,
@@ -202,6 +272,21 @@ class BackendEndpointTests(TestCase):
         self.assertEqual(first_station["region"]["has_pattern_station"], False)
         self.assertEqual(first_station["coordinates"], [-25.3, -57.5])
         self.assertEqual(first_station["aqi_pm2_5"], 84.0)
+
+    def test_station_list_excludes_inactive_or_invalid_data_stations(self):
+        response = self.client.get(reverse("stations-list"))
+
+        self.assertEqual(response.status_code, 200)
+        stations_ids = [station["id"] for station in response.json()]
+
+        self.assertIn(self.station.id, stations_ids)
+        self.assertIn(self.region_station_2.id, stations_ids)
+        self.assertIn(self.other_station.id, stations_ids)
+        self.assertNotIn(self.stale_station.id, stations_ids)
+        self.assertNotIn(self.no_aqi_station.id, stations_ids)
+        self.assertNotIn(self.off_station.id, stations_ids)
+        self.assertNotIn(self.pattern_station.id, stations_ids)
+        self.assertNotIn(self.no_coordinates_station.id, stations_ids)
 
     def test_station_map_returns_station_specific_forecasts(self):
         response = self.client.get(

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
+import os
 from datetime import timedelta
 from statistics import median, quantiles
 
+from django.db.models import Max, OuterRef, Subquery
 from django.db.models.functions import TruncDate, TruncMonth, TruncWeek
 from django.utils import timezone
 from rest_framework import generics, status
@@ -259,8 +261,47 @@ class StationViewset(ModelViewSet):
     serializer_class = StationSerializer
     http_method_names = ["get"]
 
+    _ACTIVE_DATA_WINDOW_HOURS = int(
+        os.getenv("BACKEND_ACTIVE_STATION_DATA_MAX_AGE_HOURS", "6")
+    )
+
     def list(self, request, *args, **kwargs):
-        queryset = self.get_queryset()
+        latest_network_reading_at = StationReadingsGold.objects.aggregate(
+            latest=Max("date_utc")
+        )["latest"]
+        if latest_network_reading_at is None:
+            return Response([])
+
+        activity_cutoff = latest_network_reading_at - timedelta(
+            hours=self._ACTIVE_DATA_WINDOW_HOURS
+        )
+
+        latest_station_reading = StationReadingsGold.objects.filter(
+            station_id=OuterRef("pk")
+        ).order_by("-date_utc")
+
+        # Active stations are on, mappable, non-pattern, and have recent valid AQI.
+        queryset = (
+            self.get_queryset()
+            .annotate(
+                latest_aqi_pm2_5=Subquery(
+                    latest_station_reading.values("aqi_pm2_5")[:1]
+                ),
+                latest_reading_at=Subquery(
+                    latest_station_reading.values("date_utc")[:1]
+                ),
+            )
+            .filter(
+                is_station_on=True,
+                is_pattern_station=False,
+                latitude__isnull=False,
+                longitude__isnull=False,
+                latest_aqi_pm2_5__isnull=False,
+                latest_reading_at__isnull=False,
+                latest_reading_at__gte=activity_cutoff,
+            )
+            .order_by("id")
+        )
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
## Summary
This PR implements backend filtering so only active stations with valid and recent data are returned by `/api/stations`, preventing non-functional stations from being displayed in the web app.

## Problem
Stations without current or valid data were still being shown to users, which caused confusion and reduced trust in the platform.

## What was implemented

### 1. Active station criteria (backend)
In `backend/api/views.py` (`StationViewset.list`), stations are now included only if they meet all of the following:

1. `is_station_on = true`
2. `is_pattern_station = false`
3. `latitude` and `longitude` are present
4. Latest AQI value (`aqi_pm2_5`) is not null
5. Latest reading is recent enough (within a configurable time window)

### 2. Recency window configuration
Added environment variable:

- `BACKEND_ACTIVE_STATION_DATA_MAX_AGE_HOURS=6` (default)

This window is evaluated relative to the latest available network reading timestamp.

### 3. Serializer optimization
In `backend/api/serializers.py`, `StationSerializer.get_aqi_pm2_5` now reuses annotated AQI values when available to avoid extra per-station queries.

### 4. Tests
In `backend/api/tests.py`, added representative cases to verify that `/api/stations` excludes:

- stale stations
- stations with null AQI
- manually off stations
- pattern stations
- stations without coordinates

And keeps active/valid stations visible.

## DoD coverage
- Inactive stations are no longer returned in relevant station views.
- Active stations remain visible and unaffected.
- Logic is validated with representative test data.

## Notes
- Added docs for the new env var in:
  - `backend/.env.example`
  - `backend/README.md`