### PR TITLE
[RES-160]Fix “Datos” dropdown not opening from “Sobre nosotros” page

### DIFF
--- a/frontend/src/components/NavbarItem.astro
+++ b/frontend/src/components/NavbarItem.astro
@@ -3,10 +3,7 @@ export const prerender = false;
 
 import Typography from "./atoms/Typography.astro";
 import { BASE_URL } from "../data/constants";
-import { Dropdown, DropdownItems } from "astro-navbar";
-import { Image } from "astro:assets";
-import DropdownIcon from "../assets/icons/dropdown_icon.svg";
-import { DropdownData } from "./react/nav/DropdownData";
+import { NavDropdown } from "./react/nav/NavDropdown";
 const { title, route, type } = Astro.props;
 
 let isModal = type === "modal";
@@ -52,28 +49,9 @@ let isDropdown = type === "dropdown";
 
 {
   !isModal && isDropdown && (
-    <Dropdown class="group">
-      <button>
-        <li class="place-content-center cursor-default flex-row flex">
-          <Typography variant="nav" customClass="m-auto select-none">
-            {title}
-          </Typography>
-          <Image
-            class="h-6 w-auto"
-            alt="Respira"
-            src={DropdownIcon}
-            loading="eager"
-          />
-        </li>
-      </button>
-      <DropdownItems class="md:relative">
-        <div class="md:absolute md:top-8 bg-base md:p-6 pt-2 md:pt-0 rounded min-w-36">
-          <ul class="flex flex-col">
-            <DropdownData client:only="react" {...route} />
-          </ul>
-        </div>
-      </DropdownItems>
-    </Dropdown>
+    <li class="place-content-center cursor-default">
+      <NavDropdown client:load title={title} {...route} />
+    </li>
   )
 }
 

--- a/frontend/src/components/react/nav/NavDropdown.tsx
+++ b/frontend/src/components/react/nav/NavDropdown.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect, useRef } from "react";
+import { useStore } from "@nanostores/react";
+
+import { loadingStations, stations } from "../../../store/map";
+import type { DynamicMenuItem } from "../../../data/menu";
+import type { STATION } from "../../../store/map";
+import DropdownIcon from "../../../assets/icons/dropdown_icon.svg?react";
+
+type NavDropdownProps = DynamicMenuItem & {
+  title: string;
+};
+
+const NavDropdown = ({ title, baseRoute, titleKey, subtitleKey }: NavDropdownProps) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const data = useStore(stations);
+  const loading = useStore(loadingStations);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+        aria-expanded={open}
+        className="flex flex-row items-center cursor-default"
+      >
+        <h6 className="font-serif font-bold text-[1rem] text-black text-start select-none">
+          {title}
+        </h6>
+        <DropdownIcon className="h-6 w-auto" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div className="md:absolute md:top-8 bg-base md:p-6 pt-2 md:pt-0 rounded min-w-36 z-50">
+          <ul className="flex flex-col">
+            {loading && (
+              <div className="animate-pulse flex flex-col space-y-4">
+                <div className="h-10 w-full bg-basedark rounded"></div>
+                <div className="h-10 w-full bg-basedark rounded"></div>
+                <div className="h-10 w-full bg-basedark rounded"></div>
+              </div>
+            )}
+            {!loading &&
+              data &&
+              data.map((val: STATION) => {
+                const valueMap = val as Record<string, unknown>;
+                return (
+                  <li key={val.id} className="py-2">
+                    <a href={baseRoute + "/" + val.id}>
+                      <p className="font-serif font-bold text-[1rem] text-black">
+                        Estación {String(valueMap[titleKey] ?? "")}
+                      </p>
+                      <p className="font-sans text-[0.75rem] text-black">
+                        {String(valueMap[subtitleKey] ?? "")}
+                      </p>
+                    </a>
+                  </li>
+                );
+              })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export { NavDropdown };

--- a/frontend/src/components/react/nav/NavDropdown.tsx
+++ b/frontend/src/components/react/nav/NavDropdown.tsx
@@ -39,17 +39,20 @@ const NavDropdown = ({
           setOpen((prev) => !prev);
         }}
         aria-expanded={open}
-        className="flex flex-row items-center cursor-default"
+        className="flex flex-row items-center gap-1 cursor-default"
       >
         <h6 className="font-serif font-bold text-[1rem] text-black text-start select-none">
           {title}
         </h6>
-        <DropdownIcon className="h-6 w-auto" aria-hidden="true" />
+        <DropdownIcon
+          className={`h-6 w-auto transition-transform duration-200 ${open ? "rotate-180" : "rotate-0"}`}
+          aria-hidden="true"
+        />
       </button>
 
       {open && (
-        <div className="md:absolute md:top-8 bg-base md:p-6 pt-2 md:pt-0 rounded min-w-36 z-50">
-          <ul className="flex flex-col">
+        <div className="mt-2 md:mt-0 md:absolute md:top-10 md:left-0 bg-base md:p-3 pt-2 rounded-xl w-64 max-w-[78vw] z-50 shadow-xl border border-basedark/20">
+          <ul className="flex flex-col gap-1 max-h-[min(24rem,calc(100vh-9rem))] overflow-y-auto overscroll-contain pr-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:w-0">
             {loading && (
               <div className="animate-pulse flex flex-col space-y-4">
                 <div className="h-10 w-full bg-basedark rounded"></div>
@@ -62,12 +65,15 @@ const NavDropdown = ({
               data.map((val: STATION) => {
                 const valueMap = val as Record<string, unknown>;
                 return (
-                  <li key={val.id} className="py-2">
-                    <a href={baseRoute + "/" + val.id}>
-                      <p className="font-serif font-bold text-[1rem] text-black">
+                  <li
+                    key={val.id}
+                    className="rounded-lg px-3 py-2 hover:bg-basedark/10 transition-colors duration-150"
+                  >
+                    <a href={baseRoute + "/" + val.id} className="block">
+                      <p className="font-serif font-bold text-[1rem] text-black leading-tight">
                         Estación {String(valueMap[titleKey] ?? "")}
                       </p>
-                      <p className="font-sans text-[0.75rem] text-black">
+                      <p className="font-sans text-[0.75rem] text-black/70 leading-snug mt-1">
                         {String(valueMap[subtitleKey] ?? "")}
                       </p>
                     </a>

--- a/frontend/src/components/react/nav/NavDropdown.tsx
+++ b/frontend/src/components/react/nav/NavDropdown.tsx
@@ -10,7 +10,12 @@ type NavDropdownProps = DynamicMenuItem & {
   title: string;
 };
 
-const NavDropdown = ({ title, baseRoute, titleKey, subtitleKey }: NavDropdownProps) => {
+const NavDropdown = ({
+  title,
+  baseRoute,
+  titleKey,
+  subtitleKey,
+}: NavDropdownProps) => {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const data = useStore(stations);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,5 +28,6 @@
     // Allow JSX files (or files that are internally considered JSX, like Astro files) to be imported inside `.js` and `.ts` files.
     "jsx": "preserve",
     "strict": true
-  }
+  },
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

- The "Datos" navbar dropdown failed to open on `/nosotros`, `/recursos`, and `/contacto` due to a race condition between `astro-navbar`'s `addListeners()` initialization and Astro's `client:only` React hydration
- `astro-navbar` queries all `.astronav-dropdown` elements (both the outer `<menu>` and the inner `DropdownItems` `<div>` share this class) and calls `cloneAndReplace` on them at `DOMContentLoaded` — if this runs before React hydrates `DropdownData`, the original DOM node is removed and the click listener is never registered on the cloned button
- The failure was intermittent because pages with many React islands (e.g. `/`, `/datos`) had React already loaded, making hydration fast enough to win the race; simpler pages consistently lost it
- Replaced the `Dropdown` / `DropdownItems` / `DropdownData` (astro-navbar) trio with a single self-contained React component `NavDropdown.tsx` that owns its open/close state via `useState`, handles click-outside via a `useEffect` cleanup listener, and hydrates eagerly with `client:load` — eliminating the race condition entirely

## Test plan

- [ ] Navigate to `/nosotros`, click "Datos" — dropdown opens
- [ ] Navigate to `/recursos`, click "Datos" — dropdown opens
- [ ] Navigate to `/contacto`, click "Datos" — dropdown opens
- [ ] Hard reload each affected page and confirm dropdown still opens on first click
- [ ] Verify dropdown closes when clicking outside of it
- [ ] Verify clicking a station link inside the dropdown navigates correctly
- [ ] Confirm no regression on `/` and `/datos` routes
