### PR TITLE
[RES-197-198] - Implement geolocated region AQI endpoint and Implement nearest station geolocation endpoint

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,7 +3,14 @@ from rest_framework.routers import DefaultRouter
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from .views import StationViewset, RegionViewset, MapViewset, HealthCheckView
+from .views import (
+    StationViewset,
+    RegionViewset,
+    MapViewset,
+    HealthCheckView,
+    NearestRegionView,
+    NearestStationView,
+)
 
 router = DefaultRouter()
 
@@ -11,6 +18,8 @@ router.register(r"regions", RegionViewset, basename="regions")
 router.register(r"stations", StationViewset, basename="stations")
 
 urlpatterns = [
+    path(r"map/nearest-region/", NearestRegionView.as_view(), name="nearest-region"),
+    path(r"stations/nearest/", NearestStationView.as_view(), name="nearest-station"),
     path(r"", include(router.urls)),
     path(r"map/", MapViewset.as_view(), name="map"),
     path(r"health/", HealthCheckView.as_view(), name="health"),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import timedelta
+from math import asin, cos, radians, sin, sqrt
 from statistics import median, quantiles
 
 from django.db.models.functions import TruncDate, TruncMonth, TruncWeek
@@ -106,6 +107,56 @@ def _latest_station_forecasts(station_id):
             return inference_run, forecast_6h, forecast_12h
 
     return None, [], []
+
+
+def _parse_lat_lon(request):
+    lat_raw = request.query_params.get("lat")
+    lon_raw = request.query_params.get("lon")
+    if lat_raw is None or lon_raw is None:
+        return None, None, Response(
+            {"error": "Both 'lat' and 'lon' query parameters are required."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    try:
+        lat = float(lat_raw)
+        lon = float(lon_raw)
+    except ValueError:
+        return None, None, Response(
+            {"error": "'lat' and 'lon' must be valid numbers."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lon <= 180.0):
+        return None, None, Response(
+            {"error": "'lat' must be in [-90,90] and 'lon' in [-180,180]."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return lat, lon, None
+
+
+def _haversine_km(lat1, lon1, lat2, lon2):
+    r = 6371.0
+    p1, p2 = radians(lat1), radians(lat2)
+    dphi = radians(lat2 - lat1)
+    dlam = radians(lon2 - lon1)
+    a = sin(dphi / 2) ** 2 + cos(p1) * cos(p2) * sin(dlam / 2) ** 2
+    return 2 * r * asin(sqrt(a))
+
+
+def _nearest_active_station(lat, lon):
+    candidates = Stations.objects.filter(
+        is_station_on=True,
+        is_pattern_station=False,
+        latitude__isnull=False,
+        longitude__isnull=False,
+    )
+    nearest = None
+    nearest_distance = None
+    for station in candidates:
+        distance = _haversine_km(lat, lon, station.latitude, station.longitude)
+        if nearest_distance is None or distance < nearest_distance:
+            nearest = station
+            nearest_distance = distance
+    return nearest, nearest_distance
 
 
 def _latest_station_inference_result(station_id):
@@ -243,6 +294,80 @@ class MapViewset(generics.GenericAPIView):
                 "aqi": latest_aqi,
                 "forecast_6h": result_forecast_6h,
                 "forecast_12h": result_forecast_12h,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+def _region_aqi_payload(region_id):
+    latest_region_reading = (
+        RegionReadings.objects.filter(region_id=region_id)
+        .order_by("-date_utc")
+        .first()
+    )
+    if latest_region_reading is None:
+        return None, Response(
+            {"error": "No readings found for this region."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    _, forecast_6h, forecast_12h = _latest_region_forecasts(region_id)
+    if not forecast_6h or not forecast_12h:
+        return None, Response(
+            {"error": "No forecast data available for this region."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    return {
+        "aqi": latest_region_reading.aqi_region_avg,
+        "forecast_6h": forecast_6h,
+        "forecast_12h": forecast_12h,
+    }, None
+
+
+class NearestRegionView(generics.GenericAPIView):
+    serializer_class = MapSerializer
+    http_method_names = ["get"]
+
+    def get(self, request, *args, **kwargs):
+        lat, lon, err = _parse_lat_lon(request)
+        if err is not None:
+            return err
+
+        nearest_station, _ = _nearest_active_station(lat, lon)
+        if nearest_station is None or nearest_station.region_id is None:
+            return Response(
+                {"error": "No region could be resolved for these coordinates."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        payload, err = _region_aqi_payload(nearest_station.region_id)
+        if err is not None:
+            return err
+
+        payload["region_id"] = nearest_station.region_id
+        return Response(payload, status=status.HTTP_200_OK)
+
+
+class NearestStationView(generics.GenericAPIView):
+    http_method_names = ["get"]
+
+    def get(self, request, *args, **kwargs):
+        lat, lon, err = _parse_lat_lon(request)
+        if err is not None:
+            return err
+
+        nearest_station, distance_km = _nearest_active_station(lat, lon)
+        if nearest_station is None:
+            return Response(
+                {"error": "No active station available."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return Response(
+            {
+                "id": nearest_station.id,
+                "distance_km": distance_km,
             },
             status=status.HTTP_200_OK,
         )

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -113,22 +113,34 @@ def _parse_lat_lon(request):
     lat_raw = request.query_params.get("lat")
     lon_raw = request.query_params.get("lon")
     if lat_raw is None or lon_raw is None:
-        return None, None, Response(
-            {"error": "Both 'lat' and 'lon' query parameters are required."},
-            status=status.HTTP_400_BAD_REQUEST,
+        return (
+            None,
+            None,
+            Response(
+                {"error": "Both 'lat' and 'lon' query parameters are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            ),
         )
     try:
         lat = float(lat_raw)
         lon = float(lon_raw)
     except ValueError:
-        return None, None, Response(
-            {"error": "'lat' and 'lon' must be valid numbers."},
-            status=status.HTTP_400_BAD_REQUEST,
+        return (
+            None,
+            None,
+            Response(
+                {"error": "'lat' and 'lon' must be valid numbers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            ),
         )
     if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lon <= 180.0):
-        return None, None, Response(
-            {"error": "'lat' must be in [-90,90] and 'lon' in [-180,180]."},
-            status=status.HTTP_400_BAD_REQUEST,
+        return (
+            None,
+            None,
+            Response(
+                {"error": "'lat' must be in [-90,90] and 'lon' in [-180,180]."},
+                status=status.HTTP_400_BAD_REQUEST,
+            ),
         )
     return lat, lon, None
 
@@ -301,9 +313,7 @@ class MapViewset(generics.GenericAPIView):
 
 def _region_aqi_payload(region_id):
     latest_region_reading = (
-        RegionReadings.objects.filter(region_id=region_id)
-        .order_by("-date_utc")
-        .first()
+        RegionReadings.objects.filter(region_id=region_id).order_by("-date_utc").first()
     )
     if latest_region_reading is None:
         return None, Response(


### PR DESCRIPTION
## Nearest region and nearest station geolocation endpoints

### Summary
- Added `GET /api/map/nearest-region/?lat=&lon=` — resolves the nearest Respira region
  based on user coordinates and returns its current AQI, 6h forecast, and 12h forecast
- Added `GET /api/stations/nearest/?lat=&lon=` — resolves the nearest active station and
  returns its ID and distance in km
- Both endpoints use Haversine distance calculated server-side; no geographic logic required
  on the frontend

### Implementation details
- Region resolution uses the nearest active, non-pattern station as a proxy (since regions
  don't store centroid coordinates)
- Input validation covers missing params, non-numeric values, and out-of-range lat/lon

### Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/map/nearest-region/` | Returns AQI + forecast for nearest region |
| GET | `/api/stations/nearest/` | Returns `{ id, distance_km }` for nearest active station |


