### PR TITLE
[RES-243] - Regional forecast calculated using single inference_run

### DIFF
--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -280,6 +280,73 @@ class BackendEndpointTests(TestCase):
             [{"timestamp": "2026-03-31 12:00:00", "value": 35.0}],
         )
 
+    def test_region_map_uses_latest_region_run_without_mixing_station_runs(self):
+        newest_success_run = self._create_inference_run(
+            run_id=uuid.UUID("00000000-0000-0000-0000-000000000006"),
+            run_date=datetime(2026, 3, 31, 13, 30, tzinfo=timezone.utc),
+            flow_run_id="flow-run-region-newest",
+            status=InferenceRuns.Status.SUCCESS,
+        )
+        InferenceResults.objects.create(
+            inference_run=newest_success_run,
+            station=self.region_station_2,
+            forecasts_6h=[{"timestamp": "2026-03-31 13:30:00", "value": 55}],
+            forecasts_12h=[{"timestamp": "2026-03-31 13:30:00", "value": 65}],
+            aqi_input=[{"timestamp": "2026-03-31 13:00:00", "value": 60}],
+        )
+
+        response = self.client.get(
+            reverse("map"), {"entity": "region", "id": self.region.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["forecast_6h"],
+            [{"timestamp": "2026-03-31 13:30:00", "value": 55.0}],
+        )
+        self.assertEqual(
+            payload["forecast_12h"],
+            [{"timestamp": "2026-03-31 13:30:00", "value": 65.0}],
+        )
+
+    def test_region_map_falls_back_when_latest_region_run_has_empty_forecasts(self):
+        newest_success_run = self._create_inference_run(
+            run_id=uuid.UUID("00000000-0000-0000-0000-000000000007"),
+            run_date=datetime(2026, 3, 31, 14, 30, tzinfo=timezone.utc),
+            flow_run_id="flow-run-region-empty",
+            status=InferenceRuns.Status.SUCCESS,
+        )
+        InferenceResults.objects.create(
+            inference_run=newest_success_run,
+            station=self.station,
+            forecasts_6h=[],
+            forecasts_12h=[],
+            aqi_input=[{"timestamp": "2026-03-31 14:00:00", "value": 84}],
+        )
+        InferenceResults.objects.create(
+            inference_run=newest_success_run,
+            station=self.region_station_2,
+            forecasts_6h=[],
+            forecasts_12h=[],
+            aqi_input=[{"timestamp": "2026-03-31 14:00:00", "value": 60}],
+        )
+
+        response = self.client.get(
+            reverse("map"), {"entity": "region", "id": self.region.id}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["forecast_6h"],
+            [{"timestamp": "2026-03-31 12:00:00", "value": 30.0}],
+        )
+        self.assertEqual(
+            payload["forecast_12h"],
+            [{"timestamp": "2026-03-31 12:00:00", "value": 35.0}],
+        )
+
     def test_station_map_resolves_latest_available_forecast_per_station(self):
         newest_success_run = self._create_inference_run(
             run_id=uuid.UUID("00000000-0000-0000-0000-000000000003"),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -54,31 +54,31 @@ def _successful_inference_runs():
 
 
 def _latest_region_forecasts(region_id):
-    stations = Stations.objects.filter(region_id=region_id, is_station_on=True)
-
-    all_forecasts_6h = []
-    all_forecasts_12h = []
-
-    for station in stations:
-        result = (
-            InferenceResults.objects.filter(
-                station=station,
-                inference_run__status=InferenceRuns.Status.SUCCESS,
-            )
-            .select_related("inference_run")
-            .order_by("-inference_run__run_date", "-inference_run__created_at")
-            .first()
+    candidate_runs = (
+        _successful_inference_runs()
+        .filter(
+            inferenceresults__station__region_id=region_id,
+            inferenceresults__station__is_station_on=True,
         )
-        if result and result.forecasts_6h:
-            all_forecasts_6h.append(result.forecasts_6h)
-        if result and result.forecasts_12h:
-            all_forecasts_12h.append(result.forecasts_12h)
+        .distinct()
+        .order_by("-run_date", "-created_at")
+    )
 
-    forecast_6h = _mean_forecast_by_timestamp(all_forecasts_6h)
-    forecast_12h = _mean_forecast_by_timestamp(all_forecasts_12h)
+    for inference_run in candidate_runs:
+        run_results = InferenceResults.objects.filter(
+            inference_run=inference_run,
+            station__region_id=region_id,
+            station__is_station_on=True,
+        )
+        forecast_6h = _mean_forecast_by_timestamp(
+            run_results.values_list("forecasts_6h", flat=True)
+        )
+        forecast_12h = _mean_forecast_by_timestamp(
+            run_results.values_list("forecasts_12h", flat=True)
+        )
 
-    if forecast_6h and forecast_12h:
-        return None, forecast_6h, forecast_12h
+        if forecast_6h and forecast_12h:
+            return inference_run, forecast_6h, forecast_12h
 
     return None, [], []
 


### PR DESCRIPTION
### Summary
This PR fixes the regional forecast calculation used by the map endpoints.

Previously, the regional 6h and 12h forecast could be built from each station’s latest successful forecast independently, which meant a single regional response could mix data from different inference_runs. That made the regional forecast inconsistent.

### What changed

- Updated regional forecast aggregation to use a single latest valid successful inference_run for the region
- Averaged only the forecasts from active stations that belong to that selected run
- Added fallback behavior so if the latest successful regional run has empty forecasts, the API uses the previous valid run
- Kept station forecast behavior unchanged
- Kept regional AQI behavior unchanged

### Why
The regional forecast should represent one coherent inference snapshot for the region, not a combination of station forecasts from different runs.

### Endpoints affected

- GET /api/map?entity=region&id=<region_id>
- GET /api/map/nearest-region/

### Tests added

- Verifies regional forecasts do not mix station data from different runs
- Verifies fallback to the previous valid regional run when the latest run has empty forecasts
- Existing tests continue covering station forecast behavior and ignoring non-success runs

### Images

In demo (before):
<img width="1382" height="1013" alt="image" src="https://github.com/user-attachments/assets/76c61f83-678f-4030-a786-7da7e2fd29fe" />


After (local deploy with this fix): 
<img width="1382" height="1013" alt="image" src="https://github.com/user-attachments/assets/b9eb06f0-ac71-4a4e-a480-d95716afb3b7" />
