### PR TITLE
[RES-234] - Prevent overlapping sensor markers on map visualization

### DIFF
--- a/frontend/src/components/react/Map.tsx
+++ b/frontend/src/components/react/Map.tsx
@@ -17,6 +17,7 @@ import Pin from "./Pin";
 
 import { getColorRange } from "../../utils";
 import { MapTooltip } from "./MapTooltip";
+import { getPixelOffsets } from "../../utils/markerOffset";
 
 import { BASE_URL } from "../../data/constants";
 
@@ -58,32 +59,36 @@ const MapComponent = () => {
     undefined,
   );
 
-  const pins = React.useMemo(
-    () =>
-      data
-        ? data.map((station, index) => (
-            <Marker
-              key={`marker-${index}`}
-              longitude={station.coordinates[1]}
-              latitude={station.coordinates[0]}
-              anchor="center"
-              onClick={(e) => {
-                // If we let the click event propagates to the map, it will immediately close the popup
-                // with `closeOnClick: true`
-                e.originalEvent.stopPropagation();
-                setPopupInfo(station);
-                setSelectedStation(station.id);
-              }}
-            >
-              <Pin
-                fill={getColorRange(station?.aqi_pm2_5 ?? 0)}
-                value={station?.aqi_pm2_5 ?? -1}
-              />
-            </Marker>
-          ))
-        : [],
-    [data],
-  );
+  const pins = React.useMemo(() => {
+    if (!data) return [];
+    const offsets = getPixelOffsets(data);
+    return data.map((station, index) => {
+      const offset = offsets[index];
+      return (
+        <Marker
+          key={`marker-${index}`}
+          longitude={station.coordinates[1]}
+          latitude={station.coordinates[0]}
+          anchor="center"
+          onClick={(e) => {
+            // If we let the click event propagates to the map, it will immediately close the popup
+            // with `closeOnClick: true`
+            e.originalEvent.stopPropagation();
+            setPopupInfo(station);
+            setSelectedStation(station.id);
+          }}
+        >
+          {/* Constant pixel offset keeps co-located sensors separated at any zoom */}
+          <div style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}>
+            <Pin
+              fill={getColorRange(station?.aqi_pm2_5 ?? 0)}
+              value={station?.aqi_pm2_5 ?? -1}
+            />
+          </div>
+        </Marker>
+      );
+    });
+  }, [data]);
 
   return (
     <div

--- a/frontend/src/utils/markerOffset.ts
+++ b/frontend/src/utils/markerOffset.ts
@@ -1,0 +1,35 @@
+
+export interface PixelOffset {
+  x: number;
+  y: number;
+}
+
+const GRID_PRECISION = 1000; 
+const PIN_SPACING_PX = 46; 
+
+
+export function getPixelOffsets<T extends { coordinates: number[] }>(
+  markers: T[]
+): PixelOffset[] {
+  const offsets: PixelOffset[] = markers.map(() => ({ x: 0, y: 0 }));
+  const groups = new Map<string, number[]>();
+
+  markers.forEach((m, i) => {
+    const key = `${Math.round(m.coordinates[0] * GRID_PRECISION)},${Math.round(m.coordinates[1] * GRID_PRECISION)}`;
+    const group = groups.get(key);
+    if (group) group.push(i);
+    else groups.set(key, [i]);
+  });
+
+  groups.forEach((indices) => {
+    const n = indices.length;
+    if (n <= 1) return;
+    const radius = Math.max(PIN_SPACING_PX / 2, PIN_SPACING_PX / 2 / Math.sin(Math.PI / n));
+    indices.forEach((idx, i) => {
+      const angle = (2 * Math.PI * i) / n - Math.PI / 2;
+      offsets[idx] = { x: radius * Math.cos(angle), y: radius * Math.sin(angle) };
+    });
+  });
+
+  return offsets;
+}

--- a/frontend/src/utils/markerOffset.ts
+++ b/frontend/src/utils/markerOffset.ts
@@ -1,15 +1,13 @@
-
 export interface PixelOffset {
   x: number;
   y: number;
 }
 
-const GRID_PRECISION = 1000; 
-const PIN_SPACING_PX = 46; 
-
+const GRID_PRECISION = 1000;
+const PIN_SPACING_PX = 46;
 
 export function getPixelOffsets<T extends { coordinates: number[] }>(
-  markers: T[]
+  markers: T[],
 ): PixelOffset[] {
   const offsets: PixelOffset[] = markers.map(() => ({ x: 0, y: 0 }));
   const groups = new Map<string, number[]>();
@@ -24,10 +22,16 @@ export function getPixelOffsets<T extends { coordinates: number[] }>(
   groups.forEach((indices) => {
     const n = indices.length;
     if (n <= 1) return;
-    const radius = Math.max(PIN_SPACING_PX / 2, PIN_SPACING_PX / 2 / Math.sin(Math.PI / n));
+    const radius = Math.max(
+      PIN_SPACING_PX / 2,
+      PIN_SPACING_PX / 2 / Math.sin(Math.PI / n),
+    );
     indices.forEach((idx, i) => {
       const angle = (2 * Math.PI * i) / n - Math.PI / 2;
-      offsets[idx] = { x: radius * Math.cos(angle), y: radius * Math.sin(angle) };
+      offsets[idx] = {
+        x: radius * Math.cos(angle),
+        y: radius * Math.sin(angle),
+      };
     });
   });
 


### PR DESCRIPTION
**Problem**
Sensors sharing the same or near-identical coordinates rendered on top
of each other on the MapLibre map. Only the front marker was clickable;
sensors behind it were inaccessible without zooming excessively.

**Solution**
Replaced the previous fixed geographic-degree offset (which failed at
different zoom levels) with a screen-space pixel offset applied via CSS
`transform: translate(x, y)` on a wrapper div inside each `<Marker>`.
Co-located sensors are detected by rounding coordinates to a ~111m
grid, then fanned out in a circle with a constant ~46px center-to-center
separation — the same spread in pixels at any zoom level.

**Changes**
- `src/utils/markerOffset.ts` — new `getPixelOffsets()` helper; groups
  co-located markers and returns a `{x, y}` pixel offset per index
- `src/components/react/Map.tsx` — computes offsets once per data
  update; wraps each `<Pin>` in a translated div

**Behavior**
- Isolated sensors: no change, zero offset, exact position
- Co-located sensors: fanned out in a ring, each individually clickable
- Consistent at all zoom levels — no re-stacking when zooming out

<img width="1512" height="982" alt="Captura de pantalla 2026-06-08 a la(s) 2 28 48 p  m" src="https://github.com/user-attachments/assets/2b24155e-e575-4591-93e6-a7eed137d987" />
