### PR TITLE
[RES-241] - Fix duplicate recommendation text in "Insalubre para grupos sensibles" AQI category (Web)

### DIFF
--- a/frontend/src/data/cards.ts
+++ b/frontend/src/data/cards.ts
@@ -66,7 +66,7 @@ export const AQI: AQICard[] = [
     recommendations: [
       "Grupos sensibles: usá tapabocas y llevá medicamentos si es necesario salir.",
       "Evitá esfuerzos prolongados al aire libre.",
-      "Evitá esfuerzos prolongados al aire libre.",
+      "Preferí actividades en espacios cerrados y ventilados.",
     ],
   },
   {


### PR DESCRIPTION

### Summary
Removes a duplicated recommendation entry in the 101–150 AQI level
("Insalubre para grupos sensibles") and replaces it with the correct
third recommendation, aligning the webapp content with the approved
catalog and the mobile app.

### What changed

**`src/data/cards.ts`**
- Removed: `"Evitá esfuerzos prolongados al aire libre."` (was listed twice)
- Added: `"Preferí actividades en espacios cerrados y ventilados."`

### DoD checklist
- [x] Duplicate recommendation removed
- [x] Content matches approved AQI recommendation catalog
- [x] Content is now consistent with the mobile app (`aqiLevels.ts`)
- [x] Layout unchanged — content-only fix

