### PR TITLE
[RES-149] - Remove hardcoded regions from frontend

### DIFF
--- a/frontend/src/components/react/Map.tsx
+++ b/frontend/src/components/react/Map.tsx
@@ -21,7 +21,7 @@ import { getColorRange, parseBbox, expandBounds } from "../../utils";
 import { MapTooltip } from "./MapTooltip";
 import { getPixelOffsets } from "../../utils/markerOffset";
 
-import { BASE_URL } from "../../data/constants";
+import { BASE_URL, MAP_FALLBACK } from "../../data/constants";
 import { useClientTranslations } from "../../i18n/client";
 
 function debounce(fn: () => void, ms: number) {

--- a/frontend/src/components/react/Map.tsx
+++ b/frontend/src/components/react/Map.tsx
@@ -4,21 +4,23 @@ import Map, {
   NavigationControl,
   Marker,
   Popup,
+  type MapRef,
 } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useStore } from "@nanostores/react";
 import {
   stations,
   loadingStations,
+  regionMeta,
   setSelectedStation,
   type STATION,
 } from "../../store/map";
 import Pin from "./Pin";
 
-import { getColorRange } from "../../utils";
+import { getColorRange, parseBbox, expandBounds } from "../../utils";
 import { MapTooltip } from "./MapTooltip";
 
-import { BASE_URL } from "../../data/constants";
+import { BASE_URL, MAP_FALLBACK } from "../../data/constants";
 
 function debounce(fn: () => void, ms: number) {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -34,6 +36,18 @@ function debounce(fn: () => void, ms: number) {
 const MapComponent = () => {
   const data = useStore(stations);
   const isLoading = useStore(loadingStations);
+  const region = useStore(regionMeta);
+
+  const mapRef = React.useRef<MapRef>(null);
+
+  const bounds = React.useMemo(() => parseBbox(region?.bbox), [region?.bbox]);
+  const maxBounds = bounds ? expandBounds(bounds, 4) : MAP_FALLBACK.maxBounds;
+
+  React.useEffect(() => {
+    if (bounds && mapRef.current) {
+      mapRef.current.fitBounds(bounds, { padding: 40, duration: 0 });
+    }
+  }, [bounds]);
 
   const [dimensions, setDimensions] = React.useState({
     height: window.innerHeight,
@@ -140,21 +154,19 @@ const MapComponent = () => {
         </div>
       )}
       <Map
+        ref={mapRef}
         initialViewState={{
-          longitude: -57.65,
-          latitude: -25.28,
-          zoom: 10.5,
+          longitude: MAP_FALLBACK.center.longitude,
+          latitude: MAP_FALLBACK.center.latitude,
+          zoom: MAP_FALLBACK.zoom,
         }}
         dragRotate={false}
         touchPitch={false}
         touchZoomRotate={true}
-        minZoom={5.5}
+        minZoom={MAP_FALLBACK.minZoom}
         attributionControl={false}
         style={{ width: "100%", height: dimensions.height * 0.75 }}
-        maxBounds={[
-          [-67.0435297482847, -28.42576579802394],
-          [-45.05865460568049, -17.608237804262302],
-        ]}
+        maxBounds={maxBounds}
         onClick={() => setSelectedStation(undefined)}
         mapStyle="https://api.maptiler.com/maps/442672a8-7228-4ab4-9780-83a9932987b5/style.json?key=NKY3xmA1haxXwc5Jm48B"
       >

--- a/frontend/src/components/react/PlaceholderMap.tsx
+++ b/frontend/src/components/react/PlaceholderMap.tsx
@@ -4,11 +4,17 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { useStore } from "@nanostores/react";
 import Pin from "./Pin";
 
-import { getColorRange } from "../../utils";
+import { getColorRange, parseBbox, expandBounds } from "../../utils";
 import { statisticsSelectedStation } from "../../store/statistics";
+import { regionMeta } from "../../store/map";
+import { MAP_FALLBACK } from "../../data/constants";
 
 const PlaceHolderMap = () => {
   const data = useStore(statisticsSelectedStation);
+  const region = useStore(regionMeta);
+
+  const bounds = parseBbox(region?.bbox);
+  const maxBounds = bounds ? expandBounds(bounds, 4) : MAP_FALLBACK.maxBounds;
 
   const [dimensions] = React.useState({
     height: 300,
@@ -20,21 +26,18 @@ const PlaceHolderMap = () => {
       {data ? (
         <Map
           initialViewState={{
-            longitude: data?.coordinates[1] || -57.65,
-            latitude: data?.coordinates[0] || -25.28,
+            longitude: data?.coordinates[1] || MAP_FALLBACK.center.longitude,
+            latitude: data?.coordinates[0] || MAP_FALLBACK.center.latitude,
             zoom: 15,
           }}
           dragRotate={false}
           touchPitch={false}
           touchZoomRotate={true}
-          minZoom={5.5}
+          minZoom={MAP_FALLBACK.minZoom}
           attributionControl={false}
           style={{ ...dimensions }}
           interactive={false}
-          maxBounds={[
-            [-67.0435297482847, -28.42576579802394],
-            [-45.05865460568049, -17.608237804262302],
-          ]}
+          maxBounds={maxBounds}
           mapStyle="https://api.maptiler.com/maps/442672a8-7228-4ab4-9780-83a9932987b5/style.json?key=NKY3xmA1haxXwc5Jm48B"
         >
           <Marker

--- a/frontend/src/data/constants.ts
+++ b/frontend/src/data/constants.ts
@@ -29,6 +29,16 @@ export const AQI_COLORS: string[] = [
 
 export const EXCLUDED_STATIONS: number[] = [101];
 
+export const MAP_FALLBACK = {
+  center: { longitude: -57.65, latitude: -25.28 },
+  zoom: 10.5,
+  minZoom: 5.5,
+  maxBounds: [
+    [-67.0435297482847, -28.42576579802394],
+    [-45.05865460568049, -17.608237804262302],
+  ] as [[number, number], [number, number]],
+};
+
 export const BACKEND_URL = import.meta.env.PUBLIC_BACKEND_URL;
 
 export const BASE_URL = import.meta.env.SITE;

--- a/frontend/src/store/map.ts
+++ b/frontend/src/store/map.ts
@@ -50,6 +50,43 @@ export const region = computed(isBackendAvailable, (backendAvailable) =>
   }),
 );
 
+export type REGION_META = {
+  id: number;
+  name: string;
+  region_code: string;
+  bbox: string | null;
+};
+
+export const errorRegionMeta = atom<string | undefined>(undefined);
+export const loadingRegionMeta = atom<boolean>(false);
+
+export const fetchRegionMeta = async (): Promise<REGION_META | undefined> => {
+  loadingRegionMeta.set(true);
+  try {
+    const response = await fetch(BACKEND_URL + `/regions/`);
+    const regions: REGION_META[] = await response.json();
+    loadingRegionMeta.set(false);
+    if (!Array.isArray(regions) || regions.length === 0) {
+      return undefined;
+    }
+    const defaultId = Number(import.meta.env.PUBLIC_REGION_DEFAULT_ID);
+    return regions.find((r) => r.id === defaultId) ?? regions[0];
+  } catch {
+    loadingRegionMeta.set(false);
+    errorRegionMeta.set("There has been an error getting the region metadata.");
+    return undefined;
+  }
+};
+
+export const regionMeta = computed(isBackendAvailable, (backendAvailable) =>
+  task(async () => {
+    if (!backendAvailable) {
+      return undefined;
+    }
+    return fetchRegionMeta();
+  }),
+);
+
 export const errorStations = atom<string | undefined>(undefined);
 export const loadingStations = atom<boolean>(false);
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -30,6 +30,36 @@ export const getAQIIndex = (aqi: number): number => {
 
 export const getColorRange = (aqi: number) => AQI_COLORS[getAQIIndex(aqi)];
 
+export type LngLatBounds = [[number, number], [number, number]];
+
+export const parseBbox = (bbox?: string | null): LngLatBounds | undefined => {
+  if (!bbox) {
+    return undefined;
+  }
+  const parts = bbox.split(",").map((p) => Number(p.trim()));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) {
+    return undefined;
+  }
+  const [minLon, minLat, maxLon, maxLat] = parts;
+  return [
+    [minLon, minLat],
+    [maxLon, maxLat],
+  ];
+};
+
+export const expandBounds = (
+  bounds: LngLatBounds,
+  factor: number,
+): LngLatBounds => {
+  const [[minLon, minLat], [maxLon, maxLat]] = bounds;
+  const lonPad = ((maxLon - minLon) * factor) / 2;
+  const latPad = ((maxLat - minLat) * factor) / 2;
+  return [
+    [minLon - lonPad, minLat - latPad],
+    [maxLon + lonPad, maxLat + latPad],
+  ];
+};
+
 export const getTextColor = (bg: string) => {
   const darks = ["aqi-red-dark", "aqi-purple-dark", "aqi-vermellion-dark"];
   if (darks.includes(bg)) {


### PR DESCRIPTION
## Summary

- Added `regionMeta` store to `src/store/map.ts` that fetches region metadata (`name`, `bbox`) from the backend's `/regions/` endpoint, selecting the region matching `PUBLIC_REGION_DEFAULT_ID` (or first available as fallback).
- Added `parseBbox` and `expandBounds` helpers to `src/utils.ts` to convert the backend's `bbox` string into maplibre-compatible bounds.
- Updated `Map.tsx` to derive `initialViewState`, `maxBounds`, and map fitting from the backend region data instead of hardcoded coordinates (`-57.65, -25.28`, zoom `10.5`).
- Updated `PlaceholderMap.tsx` to derive `maxBounds` from the region `bbox` as well.
- Consolidated all hardcoded fallback values into a single `MAP_FALLBACK` constant in `src/data/constants.ts`; fallback is only used if the backend does not return a `bbox`.

## Test plan

- [ ] Map view loads and auto-fits to the region returned by `/regions/` on first render.
- [ ] Panning is constrained to the region's expanded bounds (not hardcoded Paraguay bbox).
- [ ] If the backend is unavailable or returns no `bbox`, the map falls back to the default view without errors.
- [ ] Station detail `PlaceholderMap` (`/datos/:id`) renders correctly and respects region-derived `maxBounds`.
- [ ] No TypeScript or ESLint errors introduced (`tsc --noEmit`, `eslint` clean on changed files).
